### PR TITLE
Make poetry installation in CI depend on cache miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
                 python-version: '3.10'
 
             - name: Cache poetry installation
+              id: cache-poetry
               uses: actions/cache@v4
               with:
                 path: ~/.local
@@ -33,6 +34,7 @@ jobs:
                 virtualenvs-create: true
                 virtualenvs-in-project: true
                 installer-parallel: true
+              if: steps.cache-poetry.outputs.cache-hit != 'true'
 
             - name: Cache dependencies
               id: cache-deps


### PR DESCRIPTION
Closes #14.

The installation of Poetry is made conditional on a cache miss in the previous step. This was the cause of the bug where Poetry's install script runs even if it has been loaded from the cache.