### PR TITLE
Count visits to shortened links

### DIFF
--- a/tests/test_short.py
+++ b/tests/test_short.py
@@ -6,7 +6,10 @@ from yocto import create_app
 from yocto.db import init_db, get_db
 from yocto.auth import UserAuthenticator
 from yocto.address import AddressManager
-from yocto.lib.utils import LONG_URL_IDENTIFIER, SHORT_ID_IDENTIFIER
+from yocto.lib.utils import (
+    SHORT_ID_IDENTIFIER, 
+    VISITS_COUNT_IDENTIFIER
+)
 
 
 @pytest.fixture()
@@ -59,3 +62,11 @@ def test_index_redirect_invalid(client_with_data, app):
     with app.test_request_context():
         assert url_for("pages.error") in response.request.path
     assert b"shortened address is not valid" in response.data
+
+
+def test_index_redirect_count_visits(client_with_data, app):
+    with app.app_context():
+        db = get_db()
+        visits = db.urls.find_one({SHORT_ID_IDENTIFIER: "abcdef1"})[VISITS_COUNT_IDENTIFIER]
+        client_with_data.get("/abcdef1")
+        assert db.urls.find_one({SHORT_ID_IDENTIFIER: "abcdef1"})[VISITS_COUNT_IDENTIFIER] == visits + 1

--- a/yocto/address.py
+++ b/yocto/address.py
@@ -18,6 +18,7 @@ from yocto.lib.utils import (
     SHORT_ID_IDENTIFIER,
     URL_CREATION_DATE_IDENTIFIER,
     CREATOR_USERNAME_IDENTIFIER,
+    VISITS_COUNT_IDENTIFIER,
     USERNAME_IDENTIFIER,
 )
 
@@ -124,14 +125,17 @@ class AddressManager:
                 SHORT_ID_IDENTIFIER: short_id,
                 URL_CREATION_DATE_IDENTIFIER: datetime.now(),
                 CREATOR_USERNAME_IDENTIFIER: creator_username,
+                VISITS_COUNT_IDENTIFIER: 0,
             }
         )
         
-    def lookup_short_id(self, short_id):
+    def lookup_short_id(self, short_id, count_visit=False):
         """
         Retrieve the long URL corresponding to the provided short ID.
 
         :param str short_id: The shortened URL to look up in the database.
+        :param bool count_visit: If `True`, the visit count for the ID provided is
+        incremented.
 
         :raises UrlNotFoundError: If the URL to look up is not in the database.
 
@@ -139,7 +143,10 @@ class AddressManager:
         :rtype: str
         """
         _verify_type(short_id, str)
-        result = self._urls.find_one({SHORT_ID_IDENTIFIER: short_id})
+        if count_visit:
+            result = self._urls.find_one_and_update({SHORT_ID_IDENTIFIER: short_id}, {"$inc": {VISITS_COUNT_IDENTIFIER: 1}})
+        else:
+            result = self._urls.find_one({SHORT_ID_IDENTIFIER: short_id})
         if result is None:
             raise UrlNotFoundError
         return result[LONG_URL_IDENTIFIER]

--- a/yocto/lib/utils.py
+++ b/yocto/lib/utils.py
@@ -8,6 +8,7 @@ LONG_URL_IDENTIFIER = "long_url"
 SHORT_ID_IDENTIFIER = "short_id"
 URL_CREATION_DATE_IDENTIFIER = "creation_date"
 CREATOR_USERNAME_IDENTIFIER = "creator_username"
+VISITS_COUNT_IDENTIFIER = "visits_count"
 
 def _verify_type(parameter, expected_type):
     if not isinstance(parameter, expected_type):

--- a/yocto/short.py
+++ b/yocto/short.py
@@ -15,7 +15,7 @@ def index(short_id=None):
     else:
         am = AddressManager(get_db())
         try:
-            long_url = am.lookup_short_id(short_id)
+            long_url = am.lookup_short_id(short_id, count_visit=True)
         except UrlNotFoundError:
             return redirect(url_for("pages.error", message="Sorry, this shortened address is not valid."))
         return redirect(long_url)

--- a/yocto/templates/pages/create.html
+++ b/yocto/templates/pages/create.html
@@ -2,7 +2,7 @@
 
 {% block header %}
   {% block title %}
-    <h2>Shorten a URL</h2>
+    Shorten a URL
   {% endblock title %}
 {% endblock header %}
 


### PR DESCRIPTION
Closes #11.

The number of times a shortened link has been visited is now stored in the database. When the server performs the redirect to the full URL, this count is incremented. This information could be useful for analytics in a future release or could be used to determine which links should be cached for more rapid access in a scaled-up system.