### PR TITLE
Identify users by immutable unique ID rather than chosen name

### DIFF
--- a/tests/test_short.py
+++ b/tests/test_short.py
@@ -31,10 +31,10 @@ def client_with_data(app):
     with app.app_context():
         db = get_db()
         auth = UserAuthenticator(db)
-        auth.register_user("new_user", "V4l1d_password")
+        user_id = auth.register_user("new_user", "V4l1d_password")
         am = AddressManager(db)
-        am.store_url_and_id("https://www.example.com", "abcdef1", "new_user")
-        am.store_url_and_id("https://www.example2.com", "1234567", "new_user")
+        am.store_url_and_id("https://www.example.com", "abcdef1", user_id)
+        am.store_url_and_id("https://www.example2.com", "1234567", user_id)
     return app.test_client()
 
 

--- a/yocto/lib/utils.py
+++ b/yocto/lib/utils.py
@@ -1,4 +1,5 @@
 ## Users collection identifiers ##
+USER_ID_IDENTIFIER = "_id"
 USERNAME_IDENTIFIER = "username"
 PASSWORD_HASH_IDENTIFIER = "password_hash"
 ACCOUNT_CREATION_DATE_IDENTIFIER = "creation_date"
@@ -7,7 +8,7 @@ ACCOUNT_CREATION_DATE_IDENTIFIER = "creation_date"
 LONG_URL_IDENTIFIER = "long_url"
 SHORT_ID_IDENTIFIER = "short_id"
 URL_CREATION_DATE_IDENTIFIER = "creation_date"
-CREATOR_USERNAME_IDENTIFIER = "creator_username"
+CREATOR_ID_IDENTIFIER = "creator_id"
 VISITS_COUNT_IDENTIFIER = "visits_count"
 
 def _verify_type(parameter, expected_type):


### PR DESCRIPTION
Closes #19.

In order to enable users to change their account username without losing their account data, an underlying unique ID should be associated with each user. The database already contains such a property (the database ID field) and this is now used in place of the username in most contexts not visible to the user. Name changes are not yet implemented but the backend logic now supports implementing this.