### PR TITLE
Fix display of user ID strings in place of username

### DIFF
--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -63,6 +63,19 @@ def test_index_disp(client):
     assert b"Welcome to Yocto URL shortener." in response.data  # welcome text
 
 
+def test_navigation_bar(client_with_data):
+    response = client_with_data.get("/pages/")
+    assert b"Home" in response.data
+    assert b"Sign Up" in response.data
+    assert b"Login" in response.data
+    response = client_with_data.post("/pages/login/", data={"uname": "new_user", "pw": "V4l1d_password"}, follow_redirects=True)
+    assert b"Home" in response.data
+    assert regex.search(r"<a.*>new_user</a>", response.text) is not None  # check username in link because it also appears in page body
+    assert b"Shorten URL" in response.data
+    assert b"My Links" in response.data
+    assert b"Logout" in response.data
+    
+
 def test_signup_get(client):
     response = client.get("/pages/signup/")
     assert b'<form action = "/pages/signup" method = "post">' in response.data  # display the form

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -186,7 +186,7 @@ def test_account(client_with_data):
         # Follow account route
         response = client.get("/pages/account/")
         assert regex.search(r"<header>\s+<h2>Account</h2>\s+</header>", response.text)  # display header
-        assert regex.search(r"<p>\s+" + session["user"] + r"\s+</p>", response.text)  # display header
+        assert regex.search(r"<p>\s+new_user\s+</p>", response.text)  # display header
         
 
 def test_delete(client_with_data):

--- a/yocto/templates/_navigation.html
+++ b/yocto/templates/_navigation.html
@@ -2,7 +2,7 @@
     <ul>
         <li><a href="{{ url_for('pages.index') }}">Home</a></li>
         {% if session["user"] %}
-            <li><a href="{{ url_for('pages.account') }}">{{ session["user"] }}</a></li>
+            <li><a href="{{ url_for('pages.account') }}">{{ g.user["username"] }}</a></li>
             <li><a href="{{ url_for('pages.create') }}">Shorten URL</a></li>
             <li><a href="{{ url_for('pages.my_links') }}">My Links</a></li>
             <li><a href="{{ url_for('pages.logout') }}">Logout</a></li>

--- a/yocto/templates/pages/account.html
+++ b/yocto/templates/pages/account.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <p>
-        {{ session["user"] }}
+        {{ g.user["username"] }}
     </p>
     <p><a href="{{ url_for('pages.delete') }}">Delete account</a></p>
 {% endblock content %}

--- a/yocto/templates/pages/create.html
+++ b/yocto/templates/pages/create.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
 {% block header %}
-  {% block title %}
+  <h2>{% block title %}
     Shorten a URL
-  {% endblock title %}
+  {% endblock title %}</h2>
 {% endblock header %}
 
 {% block content %}

--- a/yocto/templates/pages/my_links.html
+++ b/yocto/templates/pages/my_links.html
@@ -1,9 +1,7 @@
 {% extends "base.html" %}
 
 {% block header %}
-  {% block title %}
-    <h2>My Links</h2>
-  {% endblock title %}
+  <h2>{% block title %}My Links{% endblock title %}</h2>
 {% endblock header %}
 
 {% block content %}


### PR DESCRIPTION
Closes #22 

This PR fixes the bug where user IDs are displayed in place of usernames. Tests are included to catch similar issues if they should occur in the future.